### PR TITLE
Adds in-memory serving for the preview server

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -3,13 +3,10 @@ use std::time::Instant;
 use bunt::termcolor::{ColorChoice, StandardStream};
 
 use crate::config::Config;
-use crate::site::{BuildMode, Site};
+use crate::site::{BuildMode, DiskBackedSite, Site};
 use crate::Result;
 
-pub struct BuildCommand {
-    config: Config,
-    site: Site,
-}
+pub struct BuildCommand {}
 
 impl BuildCommand {
     pub fn run(config: Config) -> Result<()> {
@@ -19,14 +16,13 @@ impl BuildCommand {
             StandardStream::stdout(ColorChoice::Never)
         };
 
-        let site = Site::new(config.clone());
-        let cmd = BuildCommand { config, site };
+        let site = DiskBackedSite::new(config.clone());
 
-        let target_dir = &cmd.config.out_dir();
+        let target_dir = config.out_dir();
 
         bunt::writeln!(stdout, "{$bold}{$blue}Doctave | Build{/$}{/$}")?;
 
-        if let BuildMode::Release = cmd.config.build_mode() {
+        if let BuildMode::Release = config.build_mode() {
             bunt::writeln!(
                 stdout,
                 "Building site into {$bold}{}{/$} in {$bold}release mode{/$}\n",
@@ -41,7 +37,7 @@ impl BuildCommand {
         }
 
         let start = Instant::now();
-        let result = cmd.site.build();
+        let result = site.build();
         let duration = start.elapsed();
 
         if result.is_ok() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,16 +88,6 @@ impl Directory {
         &self.path
     }
 
-    fn destination(&self, out: &Path) -> PathBuf {
-        self.docs
-            .get(0)
-            .unwrap()
-            .destination(out)
-            .parent()
-            .unwrap()
-            .to_path_buf()
-    }
-
     fn index(&self) -> &Document {
         &self
             .docs

--- a/src/site.rs
+++ b/src/site.rs
@@ -58,6 +58,7 @@ impl<T: Site> Site for &T {
     }
 }
 
+#[derive(Debug)]
 pub struct InMemorySite {
     config: Config,
     contents: RwLock<HashMap<PathBuf, Vec<u8>>>,
@@ -212,15 +213,18 @@ mod test {
 
     #[test]
     fn you_can_add_a_file_and_read_it_back() {
-        let path = Path::new("index.html");
+        let path = Path::new("/workspace/site/index.html");
         let content = "An Content";
 
-        let config = Config::from_yaml_str(Path::new(""), "---\ntitle: Title").unwrap();
+        let config = Config::from_yaml_str(Path::new("/workspace"), "---\ntitle: Title").unwrap();
+
         let site = InMemorySite::new(config);
 
         site.add_file(&path, content.into()).unwrap();
 
-        assert_eq!(site.read_path(path).unwrap(), content.as_bytes());
-        assert!(site.has_file(&path));
+        let uri = Path::new("index.html");
+
+        assert_eq!(site.read_path(uri).unwrap(), content.as_bytes());
+        assert!(site.has_file(uri));
     }
 }

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+use std::sync::RwLock;
 use std::fs;
+use std::path::{Path, PathBuf};
 
 use crate::config::Config;
 use crate::site_generator::SiteGenerator;
@@ -21,18 +24,104 @@ impl std::fmt::Display for BuildMode {
     }
 }
 
-/// A handle to the output directory where the site will be generated.
-///
-/// Completely agnostic about where the original Markdown files are
-/// located. Only cares about the destination directory.
-pub struct Site {
+pub trait Site: Send + Sync {
+    fn config(&self) -> &Config;
+    fn add_file(&self, path: &Path, content: Vec<u8>) -> std::io::Result<()>;
+    fn copy_file(&self, from: &Path, to: &Path) -> std::io::Result<()>;
+    fn read_path(&self, path: &Path) -> Option<Vec<u8>>;
+    fn has_file(&self, path: &Path) -> bool;
+    fn reset(&self) -> Result<()>;
+    fn build(&self) -> Result<()>;
+}
+
+impl<T: Site> Site for &T {
+    fn config(&self) -> &Config {
+        (*self).config()
+    }
+    fn add_file(&self, path: &Path, content: Vec<u8>) -> std::io::Result<()> {
+        (*self).add_file(path, content)
+    }
+    fn copy_file(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        (*self).copy_file(to, from)
+    }
+    fn read_path(&self, path: &Path) -> Option<Vec<u8>> {
+        (*self).read_path(path)
+    }
+    fn has_file(&self, path: &Path) -> bool {
+        (*self).has_file(path)
+    }
+    fn reset(&self) -> Result<()> {
+        (*self).reset()
+    }
+    fn build(&self) -> Result<()> {
+        (*self).build()
+    }
+}
+
+pub struct InMemorySite {
+    config: Config,
+    contents: RwLock<HashMap<PathBuf, Vec<u8>>>,
+}
+
+impl InMemorySite {
+    pub fn new(config: Config) -> Self {
+        InMemorySite {
+            config,
+            contents: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl Site for InMemorySite {
+    fn config(&self) -> &Config {
+        &self.config
+    }
+
+    fn add_file(&self, path: &Path, content: Vec<u8>) -> std::io::Result<()> {
+        let mut contents = self.contents.write().unwrap();
+
+        let path = path.strip_prefix(self.config.out_dir()).unwrap();
+
+        contents.insert(path.to_owned(), content.into());
+        Ok(())
+    }
+
+    fn copy_file(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        let content = fs::read(from)?;
+        self.add_file(to, content)
+    }
+
+    fn read_path(&self, path: &Path) -> Option<Vec<u8>> {
+        let contents = self.contents.read().unwrap();
+        contents.get(path).map(|s| s.clone())
+    }
+
+    fn has_file(&self, path: &Path) -> bool {
+        let contents = self.contents.read().unwrap();
+        contents.contains_key(path)
+    }
+
+    fn reset(&self) -> Result<()> {
+        let mut contents = self.contents.write().unwrap();
+        *contents = HashMap::new();
+
+        Ok(())
+    }
+
+    fn build(&self) -> Result<()> {
+        let generator = SiteGenerator::new(self);
+
+        generator.run()
+    }
+}
+
+pub struct DiskBackedSite {
     config: Config,
 }
 
-impl Site {
-    /// Create a new handle to a site output directory.
-    pub fn new(config: Config) -> Site {
-        Site { config }
+impl DiskBackedSite {
+    pub fn new(config: Config) -> Self {
+        DiskBackedSite { config }
     }
 
     pub fn create_dir(&self) -> Result<()> {
@@ -62,17 +151,76 @@ impl Site {
 
         Ok(())
     }
+}
 
-    pub fn reset(&self) -> Result<()> {
+impl Site for DiskBackedSite {
+    fn config(&self) -> &Config {
+        &self.config
+    }
+
+    fn add_file(&self, path: &Path, content: Vec<u8>) -> std::io::Result<()> {
+        fs::create_dir_all(
+            self.config
+                .out_dir()
+                .join(path.parent().expect("Path had no parent directory")),
+        )?;
+
+        fs::write(self.config.out_dir().join(path), &content)?;
+
+        Ok(())
+    }
+
+    fn copy_file(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        fs::create_dir_all(
+            self.config
+                .out_dir()
+                .join(to.parent().expect("Path had no parent directory")),
+        )?;
+
+        fs::copy(from, to).map(|_| ())
+    }
+
+    fn read_path(&self, path: &Path) -> Option<Vec<u8>> {
+        if path.exists() {
+            Some(fs::read(path).unwrap())
+        } else {
+            None
+        }
+    }
+
+    fn has_file(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
+    fn reset(&self) -> Result<()> {
         self.delete_dir()?;
         self.create_dir()?;
 
         Ok(())
     }
 
-    pub fn build(&self) -> Result<()> {
-        let generator = SiteGenerator::new(&self.config, &self);
+    fn build(&self) -> Result<()> {
+        let generator = SiteGenerator::new(self);
 
         generator.run()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn you_can_add_a_file_and_read_it_back() {
+        let path = Path::new("index.html");
+        let content = "An Content";
+
+        let config = Config::from_yaml_str(Path::new(""), "---\ntitle: Title").unwrap();
+        let site = InMemorySite::new(config);
+
+        site.add_file(&path, content.into()).unwrap();
+
+        assert_eq!(site.read_path(path).unwrap(), content.as_bytes());
+        assert!(site.has_file(&path));
     }
 }

--- a/tests/build_cmd.rs
+++ b/tests/build_cmd.rs
@@ -431,7 +431,6 @@ integration_test!(include_header, |area| {
     );
 
     let result = area.cmd(&["build"]);
-    println!("{:?}", result);
     assert_success(&result);
 
     let index = Path::new("site").join("index.html");

--- a/tests/serve_cmd.rs
+++ b/tests/serve_cmd.rs
@@ -50,15 +50,11 @@ integration_test!(serve_smoke_test, |area| {
     request_data.push_str("\r\n");
     request_data.push_str("\r\n");
 
-    println!("request_data = {:?}", request_data);
 
-    let request = stream.write_all(request_data.as_bytes()).unwrap();
-    println!("request = {:?}", request);
+    stream.write_all(request_data.as_bytes()).unwrap();
 
     let mut buf = String::new();
-    let result = stream.read_to_string(&mut buf).unwrap();
-    println!("result = {}", result);
-    println!("buf = {}", buf);
+    stream.read_to_string(&mut buf).unwrap();
 
     sender1.send(()).unwrap();
     receiver2.recv().unwrap();


### PR DESCRIPTION
- Creates a layer for interacting with generated site: the `Site` trait
- InMemorySite and DiskBackedSite implement the trait
- `serve` and `build` commands use them respectively
- Generator is generic over `Site` trait
- InMemorySite is backed by a `RwLock<HashMap<Vec<u8>, PathBuf>>>`

Closes #4 