### PR TITLE
Make doc root configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,21 @@ Example:
 base_path: /docs
 ```
 
+### docs_dir
+
+Tells Doctave to use the specified path as the base path for generating documentation.
+
+This option should be used if you wish to store your documentation in a directory that is not `docs/`.
+
+This is an optional setting.
+
+Example:
+```yaml
+---
+docs_dir: custom_documentation_directory/
+---
+```
+
 ### colors.main
 
 This sets the main color for your site. You can read more about this in

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -32,6 +32,12 @@ $ doctave init
 This will create a `docs/` directory in the root of your repository, and some pages for you to get
 started with.
 
+If you wish to use a different directory than `docs/`, you can pass the name of that directory as the argument `--docs-dir`:
+```
+$ doctave init --docs-dir some_subdirectory
+...
+```
+
 You'll also find a `doctave.yaml` in your project root now. Lets take a look at it.
 
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,7 +136,8 @@ impl DoctaveYaml {
             None => "docs".to_string(),
         };
 
-        project_root.join(to_join)
+        let doc_root_path = project_root.join(to_join);
+        doc_root_path
     }
 }
 #[derive(Debug, Clone, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,13 @@ fn main() {
                 .help("Disable terminal color output")
                 .global(true),
         )
-        .subcommand(SubCommand::with_name("init").about("Initialize a new project (start here!)"))
+        .subcommand(
+            SubCommand::with_name("init")
+                .about("Initialize a new project (start here!)")
+                .arg(Arg::with_name("docs-dir").long("docs-dir").help(
+                    "An optional custom root directory for your documentation. (Defaults to docs/)",
+                ).takes_value(true)),
+        )
         .subcommand(
             SubCommand::with_name("build")
                 .about("Builds your site from the project's Markdown files")
@@ -61,7 +67,8 @@ fn main() {
 
 fn init(cmd: &ArgMatches) -> doctave::Result<()> {
     let root_dir = std::env::current_dir().expect("Unable to determine current directory");
-    doctave::InitCommand::run(root_dir, !cmd.is_present("no-color"))
+    let doc_root = cmd.value_of("docs-dir").map(|str| str.to_string());
+    doctave::InitCommand::run(root_dir, !cmd.is_present("no-color"), doc_root)
 }
 
 fn build(cmd: &ArgMatches) -> doctave::Result<()> {

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -80,10 +80,7 @@ impl<'a> Navigation<'a> {
             let mut without_docs_part = path.components();
             let _ = without_docs_part.next();
 
-            let link_path = link
-                    .path
-                    .strip_prefix(self.config.base_path())
-                    .unwrap();
+            let link_path = link.path.strip_prefix(self.config.base_path()).unwrap();
 
             let doc_path = Link::path_to_uri(without_docs_part.as_path());
 
@@ -177,7 +174,7 @@ mod test {
             Path::new(path),
             "Not important".to_string(),
             frontmatter,
-            base_path.unwrap_or("/")
+            base_path.unwrap_or("/"),
         )
     }
 
@@ -191,14 +188,14 @@ mod test {
     fn basic() {
         let config = config(None);
         let root = Directory {
-            path: PathBuf::from("docs"),
+            path: config.docs_dir().to_path_buf(),
             docs: vec![
                 page("README.md", "Getting Started", None),
                 page("one.md", "One", None),
                 page("two.md", "Two", None),
             ],
             dirs: vec![Directory {
-                path: PathBuf::from("docs").join("child"),
+                path: config.docs_dir().join("child"),
                 docs: vec![
                     page("child/README.md", "Nested Root", None),
                     page("child/three.md", "Three", None),
@@ -546,22 +543,14 @@ mod test {
         let root = Directory {
             path: PathBuf::from("docs"),
             docs: vec![
-                page(
-                    "README.md",
-                    "Getting Started",
-                    Some(config.base_path()),
-                ),
+                page("README.md", "Getting Started", Some(config.base_path())),
                 page("one.md", "One", Some(config.base_path())),
                 page("two.md", "Two", Some(config.base_path())),
             ],
             dirs: vec![Directory {
                 path: PathBuf::from("docs").join("child"),
                 docs: vec![
-                    page(
-                        "child/README.md",
-                        "Nested Root",
-                        Some(config.base_path()),
-                    ),
+                    page("child/README.md", "Nested Root", Some(config.base_path())),
                     page("child/three.md", "Three", Some(config.base_path())),
                 ],
                 dirs: vec![],

--- a/src/preview_server.rs
+++ b/src/preview_server.rs
@@ -17,12 +17,7 @@ pub struct PreviewServer {
 }
 
 impl PreviewServer {
-    pub fn new(
-        addr: &str,
-        site: Arc<InMemorySite>,
-        color: bool,
-        base_path: String,
-    ) -> Self {
+    pub fn new(addr: &str, site: Arc<InMemorySite>, color: bool, base_path: String) -> Self {
         PreviewServer {
             addr: addr.parse().expect("invalid address for preview server"),
             site,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -40,7 +40,7 @@ impl ServeCommand {
         // Watcher ------------------------------------
 
         let (watch_snd, watch_rcv) = bounded(128);
-        let watcher = Watcher::new(vec![config.project_root().join("docs")], watch_snd);
+        let watcher = Watcher::new(vec![config.docs_dir().to_path_buf()], watch_snd);
         thread::Builder::new()
             .name("watcher".into())
             .spawn(move || watcher.run())

--- a/src/site_generator.rs
+++ b/src/site_generator.rs
@@ -40,7 +40,7 @@ impl<'a, T: Site> SiteGenerator<'a, T> {
     }
 
     pub fn run(&self) -> Result<()> {
-        let root = self.find_docs(self.config.project_root());
+        let root = self.find_docs();
         let nav_builder = Navigation::new(&self.config);
         let navigation = nav_builder.build_for(&root);
 
@@ -219,10 +219,7 @@ impl<'a, T: Site> SiteGenerator<'a, T> {
                     project_title: self.config.title().to_string(),
                     logo: self.config.logo().map(|l| l.to_string()),
                     build_mode: self.config.build_mode().to_string(),
-                    base_path: self
-                        .config
-                        .base_path()
-                        .to_owned(),
+                    base_path: self.config.base_path().to_owned(),
                     timestamp: &self.timestamp,
                     page_title,
                     head_include,
@@ -279,14 +276,12 @@ impl<'a, T: Site> SiteGenerator<'a, T> {
         }
     }
 
-    fn find_docs(&self, project_root: &Path) -> Directory {
-        let mut root_dir = self
-            .walk_dir(project_root.join("docs"))
-            .unwrap_or(Directory {
-                path: project_root.join("docs"),
-                docs: vec![],
-                dirs: vec![],
-            });
+    fn find_docs(&self) -> Directory {
+        let mut root_dir = self.walk_dir(self.config.docs_dir()).unwrap_or(Directory {
+            path: self.config.docs_dir().to_path_buf(),
+            docs: vec![],
+            dirs: vec![],
+        });
 
         self.generate_missing_indices(&mut root_dir);
 

--- a/tests/init_cmd.rs
+++ b/tests/init_cmd.rs
@@ -99,3 +99,32 @@ integration_test!(skips_generating_docs_if_docs_folder_exists, |area| {
     area.refute_exists(Path::new("docs").join("examples.md"));
     area.assert_exists(Path::new("doctave.yaml"));
 });
+
+integration_test!(custom_docsdir_generates, |area| {
+    let result = area.cmd(&["init", "--docs-dir", "custom_docs_dir"]);
+    assert_success(&result);
+
+    area.assert_contains(
+        Path::new("doctave.yaml"),
+        indoc! {"
+        ---
+        title: \"My Project\"
+        
+        docs_dir: custom_docs_dir
+    "},
+    );
+
+    area.assert_exists(Path::new("custom_docs_dir").join("README.md"));
+    area.assert_exists(Path::new("custom_docs_dir").join("examples.md"));
+});
+
+integration_test!(custom_docsdir_skips_generating_if_path_exists, |area| {
+    area.mkdir("custom_docs_dir");
+
+    let result = area.cmd(&["init", "--docs-dir", "custom_docs_dir"]);
+    assert_success(&result);
+
+    area.refute_exists(Path::new("custom_docs_dir").join("README.md"));
+    area.refute_exists(Path::new("custom_docs_dir").join("examples.md"));
+    area.assert_exists(Path::new("doctave.yaml"));
+});


### PR DESCRIPTION
See title.

This simply starts using the facilities that were already in place to configure the documentation root.

Expand `doctave init` so that you can select which directory should be used as document root

Fixes #20

Unsure what/if there is anything that can be tested here, since all that really changes is that this path is now read from the configuration file instead of using the default `docs/` 

