### PR TITLE
Fix issue 18

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -232,6 +232,15 @@ impl NavRule {
             ),
         }
     }
+
+    pub fn is_default_readme_rule(&self, root_dir: &Path, docs_dir: &Path) -> bool {
+        let my_path = match self {
+            NavRule::File(path) => path,
+            NavRule::Dir(_, _) => return false,
+        };
+
+        root_dir.join(my_path) == docs_dir.join("README.md")
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl Directory {
             .expect("No index file found for directory")
     }
 
-    fn links(&self) -> Vec<Link> {
+    fn links(&self, include_root_readme: bool) -> Vec<Link> {
         let mut links = self
             .docs
             .iter()
@@ -104,7 +104,11 @@ impl Directory {
                 path: d.uri_path(),
                 children: vec![],
             })
-            .filter(|l| l.path != self.index().uri_path())
+            // Filter out the index for each sub-link, but not the default/README file
+            .filter(|l| {
+                l.path != self.index().uri_path()
+                    || (l.path == "/".to_string() && include_root_readme)
+            })
             .collect::<Vec<_>>();
 
         let mut children = self
@@ -113,7 +117,7 @@ impl Directory {
             .map(|d| Link {
                 title: d.index().title().to_owned(),
                 path: d.index().uri_path(),
-                children: d.links(),
+                children: d.links(include_root_readme),
             })
             .collect::<Vec<_>>();
 

--- a/tests/build_cmd.rs
+++ b/tests/build_cmd.rs
@@ -549,3 +549,31 @@ integration_test!(base_path_with_logo, |area| {
     area.refute_contains(&index, "<a href=\"/\">");
     area.refute_contains(&index, "<a href='/'>");
 });
+
+// See (Issue 18)[https://github.com/Doctave/doctave/issues/18]
+integration_test!(issue_18, |area| {
+    area.write_file(
+        Path::new("doctave.yaml"),
+        indoc! {"
+    ---
+    title: Test project
+    navigation:
+        - path: docs/README.md
+        - path: docs/another_file.md
+    "}
+        .as_bytes(),
+    );
+    area.mkdir("docs");
+
+    area.write_file(
+        Path::new("docs").join("README.md"),
+        indoc! {"# A test file"}.as_bytes(),
+    );
+    area.write_file(
+        Path::new("docs").join("another_file.md"),
+        indoc! {"# A second test file"}.as_bytes(),
+    );
+
+    let result = area.cmd(&["build"]);
+    assert_success(&result);
+});


### PR DESCRIPTION
See title.

For now, we simply ignore the README file if it is included in the navigation.

Should the user somehow be notified that this happened?

Fixes #18 