### PR TITLE
Broken link checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,8 +317,8 @@ dependencies = [
 
 [[package]]
 name = "doctave-markdown"
-version = "0.7.1"
-source = "git+https://github.com/Doctave/doctave-markdown?tag=0.7.1#4529651ff763bc6b6b940e84feb741f0cc329a68"
+version = "0.7.2"
+source = "git+https://github.com/Doctave/doctave-markdown?tag=0.7.2#96540095d37910781a8af6168761fe24ccc8915b"
 dependencies = [
  "ammonia",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 clap = "2.33.3"
 walkdir = "2.3.1"
-doctave-markdown = { git = "https://github.com/Doctave/doctave-markdown", tag = "0.7.1" }
+doctave-markdown = { git = "https://github.com/Doctave/doctave-markdown", tag = "0.7.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 handlebars = "3.4.0"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,8 +84,8 @@ docs_dir: custom_documentation_directory/
 
 ### colors.main
 
-This sets the main color for your site. You can read more about this in
-[customization](/features/customization). Currently this is the only color you can customize.
+This sets the main color for your site. You can read more about this in the
+[look-and-feel section](/features/look-and-feel). Currently this is the only color you can customize.
 
 This is an optional setting.
 
@@ -102,8 +102,8 @@ colors:
 
 ### logo
 
-The name of the file to serve as your logo. You can read more about this in
-[customization](/features/customization).
+The name of the file to serve as your logo. You can read more about this in the
+[look-and-feel section](/features/look-and-feel).
 
 This is an optional setting.
 

--- a/docs/features/checks.md
+++ b/docs/features/checks.md
@@ -1,0 +1,54 @@
+---
+title: Checks
+---
+
+Checks
+======
+
+Doctave will over time add various checks that can be run as part of your build. When you run `doctave build`, you will
+see any failed checks in the terminal output. To opt out of these checks, use the `--skip-checks` flag.
+
+Currently the only supported check is broken links checking.
+
+## Broken Links
+
+Broken links are links that point to pages that do not exist. Over time as you update your documentation, your links may
+become out of date as content is moved around. This check verifies that any internal links that you have in your
+documentation refer to pages that exist.
+
+You don't have to do anything to enable this feature - it is on by default. While in `serve` mode, you will see broken
+links as warnings in the terminal output. When running a `build`, any broken links will fail the build by default.
+
+Below is some example output for the `serve` command:
+
+```plain
+$ doctave serve
+
+...
+
+WARNING
+Detected broken internal links.
+The following links point to pages that do not exist:
+
+	features/markdown.md : [I don't exist](/nothing/here)
+
+```
+
+And the `build` command:
+
+```plain
+$ doctave build
+
+...
+
+ERROR: Detected broken internal links.
+The following links point to pages that do not exist:
+
+	features/markdown.md : [I don't exist](/nothing/here)
+
+```
+
+### Limitations
+
+* Only interal links within a Doctave project are checked
+* Anchor tags are not verified

--- a/docs/features/checks.md
+++ b/docs/features/checks.md
@@ -6,7 +6,7 @@ Checks
 ======
 
 Doctave will over time add various checks that can be run as part of your build. When you run `doctave build`, you will
-see any failed checks in the terminal output. To opt out of these checks, use the `--skip-checks` flag.
+see any failed checks in the terminal output. To not error out on these checks, use the `--allow-failed-checks` flag.
 
 Currently the only supported check is broken links checking.
 

--- a/docs/features/markdown.md
+++ b/docs/features/markdown.md
@@ -7,6 +7,8 @@ Markdown syntax
 
 This document walks you through all the various Markdown features and associated syntaxes.
 
+#[I don't exist](/nothing/here)
+
 ## Headings
 
 All heading types are supported.

--- a/src/broken_links_checker.rs
+++ b/src/broken_links_checker.rs
@@ -1,0 +1,167 @@
+use crate::config::Config;
+use crate::preview_server::resolve_file;
+use crate::site::{Site, SiteBackend};
+use crate::Directory;
+use crate::{Error, Result};
+
+use std::path::{Path, PathBuf};
+
+pub fn run<B: SiteBackend>(site: &Site<B>) -> Result<()> {
+    let mut broken_links = Vec::new();
+    find_broken_links(&site.root, site, &mut broken_links, &site.config);
+
+    if broken_links.len() == 0 {
+        Ok(())
+    } else {
+        Err(Error::broken_links(broken_links))
+    }
+}
+
+fn find_broken_links<B: SiteBackend>(
+    dir: &Directory,
+    site: &Site<B>,
+    broken_links: &mut Vec<(PathBuf, doctave_markdown::Link)>,
+    config: &Config,
+) {
+    for doc in &dir.docs {
+        for link in doc.outgoing_links() {
+            match &link.url {
+                doctave_markdown::UrlType::Remote(_) => {}
+                doctave_markdown::UrlType::Local(path) => {
+                    if !matches_a_target(&path, site, config.base_path()) {
+                        broken_links.push((doc.original_path().to_owned(), link.clone()))
+                    }
+                }
+            }
+        }
+    }
+
+    for child_dir in &dir.dirs {
+        find_broken_links(child_dir, site, broken_links, config);
+    }
+}
+
+fn matches_a_target<B: SiteBackend>(path: &Path, site: &Site<B>, base_path: &str) -> bool {
+    resolve_file(path, &site, base_path).is_some()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::config::Config;
+    use crate::Document;
+    use std::collections::BTreeMap;
+
+    fn page(path: &str, name: &str, content: &str) -> Document {
+        let mut frontmatter = BTreeMap::new();
+        frontmatter.insert("title".to_string(), name.to_string());
+
+        Document::new(Path::new(path), content.to_string(), frontmatter, "/")
+    }
+
+    fn config(yaml: Option<&str>) -> Config {
+        let conf = yaml.unwrap_or("---\ntitle: My project\n");
+
+        Config::from_yaml_str(&Path::new("project"), conf).unwrap()
+    }
+
+    #[test]
+    fn detects_broken_links() {
+        let config = config(None);
+
+        let root = Directory {
+            path: config.docs_dir().to_path_buf(),
+            docs: vec![page(
+                "README.md",
+                "Getting Started",
+                "[highway to hell](/dont-exist)",
+            )],
+            dirs: vec![],
+        };
+
+        let site = Site::with_root(root, config);
+
+        assert!(run(&site).is_err());
+    }
+
+    #[test]
+    fn is_fine_if_no_broken_links_exist() {
+        let config = config(None);
+
+        let root = Directory {
+            path: config.docs_dir().to_path_buf(),
+            docs: vec![
+                page("README.md", "Getting Started", "[highway to hell](/other)"),
+                page("other.md", "Getting Started", "No links!"),
+            ],
+            dirs: vec![],
+        };
+
+        let site = Site::with_root(root, config);
+        site.build().unwrap();
+        let result = run(&site);
+
+        println!("{:?}", result);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn does_not_mind_if_the_url_has_an_html_extension() {
+        let config = config(None);
+
+        let root = Directory {
+            path: config.docs_dir().to_path_buf(),
+            docs: vec![
+                page(
+                    "README.md",
+                    "Getting Started",
+                    "[highway to hell](/other.html)",
+                ),
+                page("other.md", "Getting Started", "No links!"),
+            ],
+            dirs: vec![],
+        };
+
+        let site = Site::with_root(root, config);
+        site.build().unwrap();
+        let result = run(&site);
+
+        println!("{:?}", result);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn handles_files_in_subdirectories() {
+        let config = config(None);
+
+        let root = Directory {
+            path: config.docs_dir().to_path_buf(),
+            docs: vec![
+                page(
+                    "README.md",
+                    "Getting Started",
+                    "[I'm on a](/nested/)\n[highway to hell](/nested/other.html)",
+                ),
+                page("other.md", "Getting Started", "No links!"),
+            ],
+            dirs: vec![Directory {
+                path: config.docs_dir().to_path_buf().join("nested"),
+                docs: vec![
+                    page("nested/README.md", "Nested", "Content"),
+                    page("nested/other.md", "Nested Child", "No links!"),
+                ],
+                dirs: vec![],
+            }],
+        };
+
+        let site = Site::with_root(root, config);
+        site.build().unwrap();
+        let result = run(&site);
+
+        println!("{:?}", result);
+
+        assert!(result.is_ok());
+    }
+}

--- a/src/broken_links_checker.rs
+++ b/src/broken_links_checker.rs
@@ -28,7 +28,7 @@ fn find_broken_links<B: SiteBackend>(
             match &link.url {
                 doctave_markdown::UrlType::Remote(_) => {}
                 doctave_markdown::UrlType::Local(path) => {
-                    if !matches_a_target(&path, site, config.base_path()) {
+                    if !matches_a_target(&path, site) {
                         broken_links.push((doc.original_path().to_owned(), link.clone()))
                     }
                 }
@@ -41,10 +41,8 @@ fn find_broken_links<B: SiteBackend>(
     }
 }
 
-fn matches_a_target<B: SiteBackend>(path: &Path, site: &Site<B>, base_path: &str) -> bool {
-    let full_path = Path::new(base_path).join(path.strip_prefix("/").unwrap_or(path));
-
-    resolve_file(&full_path, &site, base_path).is_some()
+fn matches_a_target<B: SiteBackend>(path: &Path, site: &Site<B>) -> bool {
+    resolve_file(path, &site).is_some()
 }
 
 #[cfg(test)]

--- a/src/broken_links_checker.rs
+++ b/src/broken_links_checker.rs
@@ -42,7 +42,9 @@ fn find_broken_links<B: SiteBackend>(
 }
 
 fn matches_a_target<B: SiteBackend>(path: &Path, site: &Site<B>, base_path: &str) -> bool {
-    resolve_file(path, &site, base_path).is_some()
+    let full_path = Path::new(base_path).join(path.strip_prefix("/").unwrap_or(path));
+
+    resolve_file(&full_path, &site, base_path).is_some()
 }
 
 #[cfg(test)]

--- a/src/broken_links_checker.rs
+++ b/src/broken_links_checker.rs
@@ -87,6 +87,7 @@ mod test {
         };
 
         let site = Site::with_root(root, config);
+        site.build().unwrap();
 
         assert!(run(&site).is_err());
     }
@@ -204,6 +205,32 @@ mod test {
                 ],
                 dirs: vec![],
             }],
+        };
+
+        let site = Site::with_root(root, config);
+        site.build().unwrap();
+        let result = run(&site);
+
+        println!("{:?}", result);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn does_not_care_about_anchor_tags_in_paths() {
+        let config = config(None);
+
+        let root = Directory {
+            path: config.docs_dir().to_path_buf(),
+            docs: vec![
+                page(
+                    "README.md",
+                    "Getting Started",
+                    "[highway to hell](/other#heading-1)",
+                ),
+                page("other.md", "Getting Started", "# Heading"),
+            ],
+            dirs: vec![],
         };
 
         let site = Site::with_root(root, config);

--- a/src/broken_links_checker.rs
+++ b/src/broken_links_checker.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 pub fn run<B: SiteBackend>(site: &Site<B>) -> Result<()> {
     let mut broken_links = Vec::new();
-    find_broken_links(&site.root, site, &mut broken_links, &site.config);
+    find_broken_links(&site.root(), site, &mut broken_links, &site.config);
 
     if broken_links.len() == 0 {
         Ok(())

--- a/src/build.rs
+++ b/src/build.rs
@@ -42,8 +42,10 @@ impl BuildCommand {
 
         if result.is_ok() {
             bunt::writeln!(stdout, "Site built in {$bold}{:?}{/$}\n", duration)?;
-        }
 
-        result
+            site.check_dead_links()
+        } else {
+            result
+        }
     }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -45,7 +45,7 @@ impl BuildCommand {
 
             let dead_links_result = site.check_dead_links();
 
-            if dead_links_result.is_err() && config.skip_checks() {
+            if dead_links_result.is_err() && config.allow_failed_checks() {
                 bunt::writeln!(stdout, "{$bold}{$yellow}WARNING{/$}{/$}")?;
                 bunt::writeln!(stdout, "{}", dead_links_result.unwrap_err())?;
                 Ok(())

--- a/src/build.rs
+++ b/src/build.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use bunt::termcolor::{ColorChoice, StandardStream};
 
 use crate::config::Config;
-use crate::site::{BuildMode, DiskBackedSite, Site};
+use crate::site::{BuildMode, Site};
 use crate::Result;
 
 pub struct BuildCommand {}
@@ -16,7 +16,7 @@ impl BuildCommand {
             StandardStream::stdout(ColorChoice::Never)
         };
 
-        let site = DiskBackedSite::new(config.clone());
+        let site = Site::disk_backed(config.clone());
 
         let target_dir = config.out_dir();
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -43,7 +43,15 @@ impl BuildCommand {
         if result.is_ok() {
             bunt::writeln!(stdout, "Site built in {$bold}{:?}{/$}\n", duration)?;
 
-            site.check_dead_links()
+            let dead_links_result = site.check_dead_links();
+
+            if dead_links_result.is_err() && config.skip_checks() {
+                bunt::writeln!(stdout, "{$bold}{$yellow}WARNING{/$}{/$}")?;
+                bunt::writeln!(stdout, "{}", dead_links_result.unwrap_err())?;
+                Ok(())
+            } else {
+                dead_links_result
+            }
         } else {
             result
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -246,7 +246,7 @@ impl NavRule {
 #[derive(Debug, Clone)]
 pub struct Config {
     color: bool,
-    skip_checks: bool,
+    allow_failed_checks: bool,
     project_root: PathBuf,
     out_dir: PathBuf,
     docs_dir: PathBuf,
@@ -278,7 +278,7 @@ impl Config {
 
         let config = Config {
             color: true,
-            skip_checks: false,
+            allow_failed_checks: false,
             project_root: project_root.to_path_buf(),
             out_dir: project_root.join("site"),
             docs_dir: doctave_yaml.docs_dir(project_root),
@@ -339,16 +339,16 @@ impl Config {
         self.color
     }
 
-    pub fn skip_checks(&self) -> bool {
-        self.skip_checks
+    pub fn allow_failed_checks(&self) -> bool {
+        self.allow_failed_checks
     }
 
     pub fn disable_colors(&mut self) {
         self.color = false
     }
 
-    pub fn disable_checks(&mut self) {
-        self.skip_checks = true
+    pub fn set_allow_failed_checks(&mut self) {
+        self.allow_failed_checks = true
     }
 
     pub fn build_mode(&self) -> BuildMode {

--- a/src/config.rs
+++ b/src/config.rs
@@ -246,6 +246,7 @@ impl NavRule {
 #[derive(Debug, Clone)]
 pub struct Config {
     color: bool,
+    skip_checks: bool,
     project_root: PathBuf,
     out_dir: PathBuf,
     docs_dir: PathBuf,
@@ -277,6 +278,7 @@ impl Config {
 
         let config = Config {
             color: true,
+            skip_checks: false,
             project_root: project_root.to_path_buf(),
             out_dir: project_root.join("site"),
             docs_dir: doctave_yaml.docs_dir(project_root),
@@ -337,8 +339,16 @@ impl Config {
         self.color
     }
 
+    pub fn skip_checks(&self) -> bool {
+        self.skip_checks
+    }
+
     pub fn disable_colors(&mut self) {
         self.color = false
+    }
+
+    pub fn disable_checks(&mut self) {
+        self.skip_checks = true
     }
 
     pub fn build_mode(&self) -> BuildMode {

--- a/src/docs_finder.rs
+++ b/src/docs_finder.rs
@@ -16,8 +16,6 @@ pub fn find(config: &Config) -> Directory {
         dirs: vec![],
     });
 
-    println!("{:#?}", root_dir);
-
     generate_missing_indices(&mut root_dir, config);
 
     root_dir

--- a/src/docs_finder.rs
+++ b/src/docs_finder.rs
@@ -1,0 +1,120 @@
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::path::Path;
+
+use crate::config::Config;
+use crate::{Directory, Document};
+
+use walkdir::WalkDir;
+
+/// Loads the current state of the documentation from disk, returning the root
+/// directory which contains all files and nested directories.
+pub fn find(config: &Config) -> Directory {
+    let mut root_dir = walk_dir(config.docs_dir(), config).unwrap_or(Directory {
+        path: config.docs_dir().to_path_buf(),
+        docs: vec![],
+        dirs: vec![],
+    });
+
+    println!("{:#?}", root_dir);
+
+    generate_missing_indices(&mut root_dir, config);
+
+    root_dir
+}
+
+fn walk_dir<P: AsRef<Path>>(dir: P, config: &Config) -> Option<Directory> {
+    let mut docs = vec![];
+    let mut dirs = vec![];
+
+    let current_dir: &Path = dir.as_ref();
+
+    for entry in WalkDir::new(&current_dir)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if entry.file_type().is_file() && entry.path().extension() == Some(OsStr::new("md")) {
+            let path = entry.path().strip_prefix(config.docs_dir()).unwrap();
+
+            docs.push(Document::load(entry.path(), path, config.base_path()));
+        } else {
+            let path = entry.into_path();
+
+            if path.as_path() == current_dir {
+                continue;
+            }
+
+            if let Some(dir) = walk_dir(path, config) {
+                dirs.push(dir);
+            }
+        }
+    }
+
+    if docs.is_empty() {
+        None
+    } else {
+        Some(Directory {
+            path: current_dir.to_path_buf(),
+            docs,
+            dirs,
+        })
+    }
+}
+
+fn generate_missing_indices(dir: &mut Directory, config: &Config) {
+    if dir
+        .docs
+        .iter()
+        .find(|d| d.original_file_name() == Some(OsStr::new("README.md")))
+        .is_none()
+    {
+        let new_index = generate_missing_index(dir, config);
+        dir.docs.push(new_index);
+    }
+
+    for mut child in &mut dir.dirs {
+        generate_missing_indices(&mut child, config);
+    }
+}
+
+fn generate_missing_index(dir: &mut Directory, config: &Config) -> Document {
+    let content = dir
+        .docs
+        .iter()
+        .map(|d| format!("* [{}]({})", d.title(), d.uri_path()))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut frontmatter = BTreeMap::new();
+    frontmatter.insert(
+        "title".to_string(),
+        format!("{}", dir.path().file_name().unwrap().to_string_lossy()),
+    );
+
+    let tmp = dir.path().join("README.md");
+    let path = tmp.strip_prefix(config.docs_dir()).unwrap();
+
+    Document::new(
+        path,
+        format!(
+            "# Index of {}\n \
+                \n \
+                This page was generated automatically by Doctave, because the directory \
+                `{}` did not contain an index `README.md` file. You can customize this page by \
+                creating one yourself.\
+                \n\
+                ## Pages\n\
+                \n\
+                {}",
+            dir.path().file_name().unwrap().to_string_lossy(),
+            dir.path()
+                .strip_prefix(config.project_root())
+                .unwrap_or_else(|_| dir.path())
+                .display(),
+            content
+        ),
+        frontmatter,
+        config.base_path(),
+    )
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,7 @@ impl fmt::Display for Error {
             ErrorKind::Handlebars(err) => write!(f, "{}:\n{}", self.message, err),
             ErrorKind::Yaml(err) => write!(f, "{}:\n{}", self.message, err),
             ErrorKind::BrokenLinks(links) => {
-                write!(f, "{}\n{}", self.message, format_broken_links(&links))
+                write!(f, "{}.\n{}", self.message, format_broken_links(&links))
             }
             ErrorKind::Generic => write!(f, "{}", self.message),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,7 @@ impl fmt::Display for Error {
             ErrorKind::Handlebars(err) => write!(f, "{}:\n{}", self.message, err),
             ErrorKind::Yaml(err) => write!(f, "{}:\n{}", self.message, err),
             ErrorKind::BrokenLinks(links) => {
-                write!(f, "{}\n\n{}", self.message, format_broken_links(&links))
+                write!(f, "{}\n{}", self.message, format_broken_links(&links))
             }
             ErrorKind::Generic => write!(f, "{}", self.message),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct Error {
@@ -34,6 +35,13 @@ impl Error {
             message: msg.into(),
         }
     }
+
+    pub fn broken_links(links: Vec<(PathBuf, doctave_markdown::Link)>) -> Self {
+        Error {
+            kind: ErrorKind::BrokenLinks(links),
+            message: "Detected broken internal links".into(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -41,6 +49,7 @@ pub enum ErrorKind {
     IO(std::io::Error),
     Handlebars(handlebars::RenderError),
     Yaml(serde_yaml::Error),
+    BrokenLinks(Vec<(PathBuf, doctave_markdown::Link)>),
     Generic,
 }
 
@@ -50,9 +59,32 @@ impl fmt::Display for Error {
             ErrorKind::IO(io_err) => write!(f, "{}:\n{}", self.message, io_err),
             ErrorKind::Handlebars(err) => write!(f, "{}:\n{}", self.message, err),
             ErrorKind::Yaml(err) => write!(f, "{}:\n{}", self.message, err),
+            ErrorKind::BrokenLinks(links) => {
+                write!(f, "{}\n\n{}", self.message, format_broken_links(&links))
+            }
             ErrorKind::Generic => write!(f, "{}", self.message),
         }
     }
+}
+
+fn format_broken_links(links: &[(PathBuf, doctave_markdown::Link)]) -> String {
+    let mut buf = String::from("The following links point to pages that do not exist:\n\n");
+
+    for (path, link) in links {
+        let url = match &link.url {
+            doctave_markdown::UrlType::Local(path) => format!("{}", path.display()),
+            doctave_markdown::UrlType::Remote(uri) => format!("{:?}", uri),
+        };
+
+        buf.push_str(&format!(
+            "\t{} : [{}]({})\n",
+            path.display(),
+            link.title,
+            url
+        ));
+    }
+
+    buf
 }
 
 impl std::error::Error for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate indoc;
 #[macro_use]
 extern crate lazy_static;
 
+mod broken_links_checker;
 mod build;
 pub mod config;
 mod error;
@@ -193,6 +194,10 @@ impl Document {
         self.path.file_name()
     }
 
+    fn original_path(&self) -> &Path {
+        &self.path
+    }
+
     /// Destination path, given an output directory
     fn destination(&self, out: &Path) -> PathBuf {
         out.join(self.html_path())
@@ -223,6 +228,10 @@ impl Document {
 
     fn headings(&self) -> &[Heading] {
         &self.markdown.headings
+    }
+
+    fn outgoing_links(&self) -> &[doctave_markdown::Link] {
+        &self.markdown.links
     }
 
     fn html(&self) -> &str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate lazy_static;
 mod broken_links_checker;
 mod build;
 pub mod config;
+mod docs_finder;
 mod error;
 mod frontmatter;
 mod init;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,8 @@ fn main() {
                         .help("Build the site in release mode"),
                 )
                 .arg(
-                    Arg::with_name("skip-checks")
-                        .long("skip-checks")
+                    Arg::with_name("allow-failed-checks")
+                        .long("allow-failed-checks")
                         .help("Don't return an error if there are failed checks"),
                 ),
         )
@@ -98,8 +98,8 @@ fn build(cmd: &ArgMatches) -> doctave::Result<()> {
         config.disable_colors();
     }
 
-    if cmd.is_present("skip-checks") {
-        config.disable_checks();
+    if cmd.is_present("allow-failed-checks") {
+        config.set_allow_failed_checks();
     }
 
     doctave::BuildCommand::run(config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use bunt::termcolor::{ColorChoice, StandardStream};
 use clap::{App, Arg, ArgMatches, SubCommand};
 
 fn main() {
@@ -27,6 +28,11 @@ fn main() {
                     Arg::with_name("release")
                         .long("release")
                         .help("Build the site in release mode"),
+                )
+                .arg(
+                    Arg::with_name("skip-checks")
+                        .long("skip-checks")
+                        .help("Don't return an error if there are failed checks"),
                 ),
         )
         .subcommand(
@@ -59,8 +65,14 @@ fn main() {
         _ => Ok(()),
     };
 
+    let mut out = if matches.value_of("no-color").is_some() {
+        StandardStream::stdout(ColorChoice::Never)
+    } else {
+        StandardStream::stdout(ColorChoice::Auto)
+    };
+
     if let Err(e) = result {
-        eprintln!("Error: {}", e);
+        bunt::writeln!(out, "{$red}ERROR:{/$} {}", e).unwrap();
         std::process::exit(1);
     }
 }
@@ -84,6 +96,10 @@ fn build(cmd: &ArgMatches) -> doctave::Result<()> {
 
     if cmd.is_present("no-color") {
         config.disable_colors();
+    }
+
+    if cmd.is_present("skip-checks") {
+        config.disable_checks();
     }
 
     doctave::BuildCommand::run(config)

--- a/src/preview_server.rs
+++ b/src/preview_server.rs
@@ -81,7 +81,7 @@ fn handle_request<B: SiteBackend>(request: Request, site: &Site<B>, base_path: &
     match result {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
-        Err(e) => eprintln!("    HTTP server threw error: {}", e),
+        Err(e) => println!("    HTTP server threw error: {}", e),
     }
 }
 

--- a/src/preview_server.rs
+++ b/src/preview_server.rs
@@ -83,7 +83,10 @@ fn handle_request<B: SiteBackend>(request: Request, site: &Site<B>, base_path: &
     }
 }
 
-fn resolve_file<B: SiteBackend>(
+/// Uses some basic logic for resolving a path into the correct file.
+/// This means resolving to an index.html from the root of the directory,
+/// trying with .html extensions with needed, etc.
+pub fn resolve_file<B: SiteBackend>(
     path: &Path,
     site: &Site<B>,
     base_path: &str,

--- a/src/preview_server.rs
+++ b/src/preview_server.rs
@@ -99,6 +99,12 @@ pub fn resolve_file<B: SiteBackend>(
 
     let mut path = path;
 
+    if path.to_str().map(|s| s.contains("#")).unwrap_or(false) {
+        let prefix = path.to_str().unwrap().split("#").next().unwrap();
+
+        path = Path::new(prefix);
+    }
+
     if path.starts_with(base_path) {
         path = path.strip_prefix(base_path).unwrap();
     } else {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -8,7 +8,7 @@ use crossbeam_channel::bounded;
 use crate::config::Config;
 use crate::livereload_server::LivereloadServer;
 use crate::preview_server::PreviewServer;
-use crate::site::{InMemorySite, Site};
+use crate::site::Site;
 use crate::watcher::Watcher;
 use crate::Result;
 
@@ -26,7 +26,7 @@ impl ServeCommand {
         } else {
             StandardStream::stdout(ColorChoice::Never)
         };
-        let site = Arc::new(InMemorySite::new(config.clone()));
+        let site = Arc::new(Site::in_memory(config.clone()));
 
         bunt::writeln!(stdout, "{$bold}{$blue}Doctave | Serve{/$}{/$}")?;
         println!("Starting development server...\n");

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -35,6 +35,12 @@ impl ServeCommand {
 
         let start = Instant::now();
         site.build().unwrap();
+
+        if let Err(e) = site.check_dead_links() {
+            bunt::writeln!(stdout, "{$bold}{$yellow}WARNING{/$}{/$}")?;
+            println!("{}", e);
+        }
+
         let duration = start.elapsed();
 
         // Watcher ------------------------------------
@@ -76,11 +82,17 @@ impl ServeCommand {
         for (path, msg) in watch_rcv {
             bunt::writeln!(stdout, "    File {$bold}{}{/$} {}.", path.display(), msg)?;
 
+            site.reset().unwrap();
             let start = Instant::now();
-            site.build().unwrap();
+            site.rebuild().unwrap();
             let duration = start.elapsed();
 
             bunt::writeln!(stdout, "    Site rebuilt in {$bold}{:?}{/$}\n", duration)?;
+
+            if let Err(e) = site.check_dead_links() {
+                bunt::writeln!(stdout, "{$bold}{$yellow}WARNING{/$}{/$}")?;
+                println!("{}", e);
+            }
 
             reload_send.send(()).unwrap();
         }

--- a/src/site.rs
+++ b/src/site.rs
@@ -6,6 +6,7 @@ use std::sync::RwLock;
 
 use walkdir::WalkDir;
 
+use crate::broken_links_checker;
 use crate::config::Config;
 use crate::site_generator::SiteGenerator;
 use crate::{Directory, Document};
@@ -50,6 +51,14 @@ impl Site<InMemorySite> {
             config,
         }
     }
+
+    pub fn with_root(root: Directory, config: Config) -> Site<InMemorySite> {
+        Site {
+            backend: InMemorySite::new(config.clone()),
+            root,
+            config,
+        }
+    }
 }
 
 impl Site<DiskBackedSite> {
@@ -70,7 +79,7 @@ impl<B: SiteBackend> Site<B> {
     }
 
     pub fn check_dead_links(&self) -> Result<()> {
-        unimplemented!()
+        broken_links_checker::run(&self)
     }
 
     fn find_docs(config: &Config) -> Directory {

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,10 +1,14 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
+use walkdir::WalkDir;
+
 use crate::config::Config;
 use crate::site_generator::SiteGenerator;
+use crate::{Directory, Document};
 use crate::{Error, Result};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -24,17 +28,171 @@ impl std::fmt::Display for BuildMode {
     }
 }
 
-pub trait Site: Send + Sync {
+#[derive(Debug, Clone)]
+/// The main handle to a site. Generic over a backend implementation.
+/// Currently has InMemory and DiskBacked backends, used for serve and build respectively.
+///
+/// When `build` is called on this struct, the backend is populated by the
+/// `SiteGenerator`.
+pub struct Site<B: SiteBackend> {
+    pub root: Directory,
+    pub backend: B,
+    pub config: Config,
+}
+
+impl Site<InMemorySite> {
+    pub fn in_memory(config: Config) -> Site<InMemorySite> {
+        let root = Self::find_docs(&config);
+
+        Site {
+            backend: InMemorySite::new(config.clone()),
+            root,
+            config,
+        }
+    }
+}
+
+impl Site<DiskBackedSite> {
+    pub fn disk_backed(config: Config) -> Site<DiskBackedSite> {
+        let root = Self::find_docs(&config);
+
+        Site {
+            backend: DiskBackedSite::new(config.clone()),
+            root,
+            config,
+        }
+    }
+}
+
+impl<B: SiteBackend> Site<B> {
+    pub fn build(&self) -> Result<()> {
+        self.backend.build(&self.root)
+    }
+
+    pub fn check_dead_links(&self) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn find_docs(config: &Config) -> Directory {
+        let mut root_dir = Self::walk_dir(config.docs_dir(), config).unwrap_or(Directory {
+            path: config.docs_dir().to_path_buf(),
+            docs: vec![],
+            dirs: vec![],
+        });
+
+        Self::generate_missing_indices(&mut root_dir, config);
+
+        root_dir
+    }
+
+    fn walk_dir<P: AsRef<Path>>(dir: P, config: &Config) -> Option<Directory> {
+        let mut docs = vec![];
+        let mut dirs = vec![];
+
+        let current_dir: &Path = dir.as_ref();
+
+        for entry in WalkDir::new(&current_dir)
+            .max_depth(1)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            if entry.file_type().is_file() && entry.path().extension() == Some(OsStr::new("md")) {
+                let path = entry.path().strip_prefix(config.docs_dir()).unwrap();
+
+                docs.push(Document::load(entry.path(), path, config.base_path()));
+            } else {
+                let path = entry.into_path();
+
+                if path.as_path() == current_dir {
+                    continue;
+                }
+
+                if let Some(dir) = Self::walk_dir(path, config) {
+                    dirs.push(dir);
+                }
+            }
+        }
+
+        if docs.is_empty() {
+            None
+        } else {
+            Some(Directory {
+                path: current_dir.to_path_buf(),
+                docs,
+                dirs,
+            })
+        }
+    }
+
+    fn generate_missing_indices(dir: &mut Directory, config: &Config) {
+        if dir
+            .docs
+            .iter()
+            .find(|d| d.original_file_name() == Some(OsStr::new("README.md")))
+            .is_none()
+        {
+            let new_index = Self::generate_missing_index(dir, config);
+            dir.docs.push(new_index);
+        }
+
+        for mut child in &mut dir.dirs {
+            Self::generate_missing_indices(&mut child, config);
+        }
+    }
+
+    fn generate_missing_index(dir: &mut Directory, config: &Config) -> Document {
+        let content = dir
+            .docs
+            .iter()
+            .map(|d| format!("* [{}]({})", d.title(), d.uri_path()))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let mut frontmatter = BTreeMap::new();
+        frontmatter.insert(
+            "title".to_string(),
+            format!("{}", dir.path().file_name().unwrap().to_string_lossy()),
+        );
+
+        let tmp = dir.path().join("README.md");
+        let path = tmp.strip_prefix(config.docs_dir()).unwrap();
+
+        Document::new(
+            path,
+            format!(
+                "# Index of {}\n \
+                \n \
+                This page was generated automatically by Doctave, because the directory \
+                `{}` did not contain an index `README.md` file. You can customize this page by \
+                creating one yourself.\
+                \n\
+                ## Pages\n\
+                \n\
+                {}",
+                dir.path().file_name().unwrap().to_string_lossy(),
+                dir.path()
+                    .strip_prefix(config.project_root())
+                    .unwrap_or_else(|_| dir.path())
+                    .display(),
+                content
+            ),
+            frontmatter,
+            config.base_path(),
+        )
+    }
+}
+
+pub trait SiteBackend: Send + Sync {
     fn config(&self) -> &Config;
     fn add_file(&self, path: &Path, content: Vec<u8>) -> std::io::Result<()>;
     fn copy_file(&self, from: &Path, to: &Path) -> std::io::Result<()>;
     fn read_path(&self, path: &Path) -> Option<Vec<u8>>;
     fn has_file(&self, path: &Path) -> bool;
     fn reset(&self) -> Result<()>;
-    fn build(&self) -> Result<()>;
+    fn build(&self, root: &Directory) -> Result<()>;
 }
 
-impl<T: Site> Site for &T {
+impl<T: SiteBackend> SiteBackend for &T {
     fn config(&self) -> &Config {
         (*self).config()
     }
@@ -53,8 +211,8 @@ impl<T: Site> Site for &T {
     fn reset(&self) -> Result<()> {
         (*self).reset()
     }
-    fn build(&self) -> Result<()> {
-        (*self).build()
+    fn build(&self, root: &Directory) -> Result<()> {
+        (*self).build(root)
     }
 }
 
@@ -73,7 +231,7 @@ impl InMemorySite {
     }
 }
 
-impl Site for InMemorySite {
+impl SiteBackend for InMemorySite {
     fn config(&self) -> &Config {
         &self.config
     }
@@ -109,8 +267,8 @@ impl Site for InMemorySite {
         Ok(())
     }
 
-    fn build(&self) -> Result<()> {
-        let generator = SiteGenerator::new(self);
+    fn build(&self, root: &Directory) -> Result<()> {
+        let generator = SiteGenerator::new(root, self);
 
         generator.run()
     }
@@ -154,7 +312,7 @@ impl DiskBackedSite {
     }
 }
 
-impl Site for DiskBackedSite {
+impl SiteBackend for DiskBackedSite {
     fn config(&self) -> &Config {
         &self.config
     }
@@ -200,8 +358,8 @@ impl Site for DiskBackedSite {
         Ok(())
     }
 
-    fn build(&self) -> Result<()> {
-        let generator = SiteGenerator::new(self);
+    fn build(&self, root: &Directory) -> Result<()> {
+        let generator = SiteGenerator::new(root, self);
 
         generator.run()
     }

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,16 +1,13 @@
-use std::collections::{BTreeMap, HashMap};
-use std::ffi::OsStr;
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
-
-use walkdir::WalkDir;
 
 use crate::broken_links_checker;
 use crate::config::Config;
 use crate::docs_finder;
 use crate::site_generator::SiteGenerator;
-use crate::{Directory, Document};
+use crate::Directory;
 use crate::{Error, Result};
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/site_generator.rs
+++ b/src/site_generator.rs
@@ -19,13 +19,13 @@ static HEAD_FILE: &str = "_head.html";
 
 pub struct SiteGenerator<'a, T: SiteBackend> {
     config: Config,
-    root: &'a Directory,
+    root: Directory,
     site: Box<&'a T>,
     timestamp: String,
 }
 
 impl<'a, T: SiteBackend> SiteGenerator<'a, T> {
-    pub fn new(root: &'a Directory, site: &'a T) -> Self {
+    pub fn new(site: &'a T) -> Self {
         let start = SystemTime::now();
 
         let since_the_epoch = start
@@ -33,7 +33,7 @@ impl<'a, T: SiteBackend> SiteGenerator<'a, T> {
             .expect("Time went backwards");
 
         SiteGenerator {
-            root,
+            root: site.root(),
             site: Box::new(site),
             config: site.config().clone(),
             timestamp: format!("{}", since_the_epoch.as_secs()),

--- a/src/site_generator.rs
+++ b/src/site_generator.rs
@@ -44,8 +44,6 @@ impl<'a, T: SiteBackend> SiteGenerator<'a, T> {
         let nav_builder = Navigation::new(&self.config);
         let navigation = nav_builder.build_for(&self.root);
 
-        self.site.reset()?;
-
         let head_include = self.read_head_include()?;
 
         self.build_includes()?;

--- a/src/site_generator.rs
+++ b/src/site_generator.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs;
-use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use elasticlunr::Index;
@@ -11,21 +10,22 @@ use walkdir::WalkDir;
 
 use crate::config::Config;
 use crate::navigation::{Link, Navigation};
-use crate::site::{BuildMode, Site};
-use crate::{Directory, Document};
+use crate::site::{BuildMode, SiteBackend};
+use crate::Directory;
 use crate::{Error, Result};
 
 static INCLUDE_DIR: &str = "_include";
 static HEAD_FILE: &str = "_head.html";
 
-pub struct SiteGenerator<'a, T: Site> {
+pub struct SiteGenerator<'a, T: SiteBackend> {
     config: Config,
+    root: &'a Directory,
     site: Box<&'a T>,
     timestamp: String,
 }
 
-impl<'a, T: Site> SiteGenerator<'a, T> {
-    pub fn new(site: &'a T) -> Self {
+impl<'a, T: SiteBackend> SiteGenerator<'a, T> {
+    pub fn new(root: &'a Directory, site: &'a T) -> Self {
         let start = SystemTime::now();
 
         let since_the_epoch = start
@@ -33,6 +33,7 @@ impl<'a, T: Site> SiteGenerator<'a, T> {
             .expect("Time went backwards");
 
         SiteGenerator {
+            root,
             site: Box::new(site),
             config: site.config().clone(),
             timestamp: format!("{}", since_the_epoch.as_secs()),
@@ -40,9 +41,8 @@ impl<'a, T: Site> SiteGenerator<'a, T> {
     }
 
     pub fn run(&self) -> Result<()> {
-        let root = self.find_docs();
         let nav_builder = Navigation::new(&self.config);
-        let navigation = nav_builder.build_for(&root);
+        let navigation = nav_builder.build_for(&self.root);
 
         self.site.reset()?;
 
@@ -50,8 +50,8 @@ impl<'a, T: Site> SiteGenerator<'a, T> {
 
         self.build_includes()?;
         self.build_assets()?;
-        self.build_directory(&root, &navigation, head_include.as_deref())?;
-        self.build_search_index(&root)?;
+        self.build_directory(&self.root, &navigation, head_include.as_deref())?;
+        self.build_search_index(&self.root)?;
 
         Ok(())
     }
@@ -274,114 +274,6 @@ impl<'a, T: Site> SiteGenerator<'a, T> {
         for dir in &root.dirs {
             self.build_search_index_for_dir(&dir, index);
         }
-    }
-
-    fn find_docs(&self) -> Directory {
-        let mut root_dir = self.walk_dir(self.config.docs_dir()).unwrap_or(Directory {
-            path: self.config.docs_dir().to_path_buf(),
-            docs: vec![],
-            dirs: vec![],
-        });
-
-        self.generate_missing_indices(&mut root_dir);
-
-        root_dir
-    }
-
-    fn walk_dir<P: AsRef<Path>>(&self, dir: P) -> Option<Directory> {
-        let mut docs = vec![];
-        let mut dirs = vec![];
-
-        let current_dir: &Path = dir.as_ref();
-
-        for entry in WalkDir::new(&current_dir)
-            .max_depth(1)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            if entry.file_type().is_file() && entry.path().extension() == Some(OsStr::new("md")) {
-                let path = entry.path().strip_prefix(self.config.docs_dir()).unwrap();
-
-                docs.push(Document::load(entry.path(), path, self.config.base_path()));
-            } else {
-                let path = entry.into_path();
-
-                if path.as_path() == current_dir {
-                    continue;
-                }
-
-                if let Some(dir) = self.walk_dir(path) {
-                    dirs.push(dir);
-                }
-            }
-        }
-
-        if docs.is_empty() {
-            None
-        } else {
-            Some(Directory {
-                path: current_dir.to_path_buf(),
-                docs,
-                dirs,
-            })
-        }
-    }
-
-    fn generate_missing_indices(&self, dir: &mut Directory) {
-        if dir
-            .docs
-            .iter()
-            .find(|d| d.original_file_name() == Some(OsStr::new("README.md")))
-            .is_none()
-        {
-            let new_index = self.generate_missing_index(dir);
-            dir.docs.push(new_index);
-        }
-
-        for mut child in &mut dir.dirs {
-            self.generate_missing_indices(&mut child);
-        }
-    }
-
-    fn generate_missing_index(&self, dir: &mut Directory) -> Document {
-        let content = dir
-            .docs
-            .iter()
-            .map(|d| format!("* [{}]({})", d.title(), d.uri_path()))
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        let mut frontmatter = BTreeMap::new();
-        frontmatter.insert(
-            "title".to_string(),
-            format!("{}", dir.path().file_name().unwrap().to_string_lossy()),
-        );
-
-        let tmp = dir.path().join("README.md");
-        let path = tmp.strip_prefix(self.config.docs_dir()).unwrap();
-
-        Document::new(
-            path,
-            format!(
-                "# Index of {}\n \
-                \n \
-                This page was generated automatically by Doctave, because the directory \
-                `{}` did not contain an index `README.md` file. You can customize this page by \
-                creating one yourself.\
-                \n\
-                ## Pages\n\
-                \n\
-                {}",
-                dir.path().file_name().unwrap().to_string_lossy(),
-                dir.path()
-                    .strip_prefix(self.config.project_root())
-                    .unwrap_or_else(|_| dir.path())
-                    .display(),
-                content
-            ),
-            frontmatter,
-            self.config.base_path(),
-        )
     }
 }
 

--- a/tests/build_cmd.rs
+++ b/tests/build_cmd.rs
@@ -615,7 +615,7 @@ integration_test!(broken_link_detection_can_be_skipped_with_flag, |area| {
         .as_bytes(),
     );
 
-    let result = area.cmd(&["build", "--skip-checks"]);
+    let result = area.cmd(&["build", "--allow-failed-checks"]);
     assert_success(&result);
 
     let stdout = std::str::from_utf8(&result.stdout).unwrap();

--- a/tests/build_cmd.rs
+++ b/tests/build_cmd.rs
@@ -462,7 +462,7 @@ integration_test!(base_path, |area| {
     area.create_config();
     area.mkdir("docs");
     area.write_file(Path::new("docs").join("README.md"), b"[link](/foo)");
-    area.write_file(Path::new("docs").join("other.md"), b"[link](/)");
+    area.write_file(Path::new("docs").join("foo.md"), b"[link](/)");
     area.write_file(
         Path::new("doctave.yaml"),
         indoc! {"
@@ -482,14 +482,14 @@ integration_test!(base_path, |area| {
     area.refute_contains(&index, "<a href=\"/\">");
     area.refute_contains(&index, "<a href='/'>");
 
-    area.refute_contains(&index, "<a href=\"/other\">");
-    area.assert_contains(&index, "<a href=\"/docs/other\">");
+    area.refute_contains(&index, "<a href=\"/foo\">");
+    area.assert_contains(&index, "<a href=\"/docs/foo\">");
 });
 
 integration_test!(base_path_with_custom_navigation, |area| {
     area.create_config();
     area.mkdir("docs");
-    area.write_file(Path::new("docs").join("README.md"), b"[link](/foo)");
+    area.write_file(Path::new("docs").join("README.md"), b"[link](/other)");
     area.write_file(Path::new("docs").join("other.md"), b"[link](/)");
     area.write_file(
         Path::new("doctave.yaml"),
@@ -520,6 +520,7 @@ integration_test!(base_path_with_logo, |area| {
     area.create_config();
     area.mkdir(Path::new("docs").join("_include").join("assets"));
     area.write_file(Path::new("docs").join("README.md"), b"[link](/foo)");
+    area.write_file(Path::new("docs").join("foo.md"), b"# Foo");
     // Create a fake logo
     area.write_file(
         Path::new("docs")
@@ -576,4 +577,28 @@ integration_test!(issue_18, |area| {
 
     let result = area.cmd(&["build"]);
     assert_success(&result);
+});
+
+integration_test!(broken_link_detection, |area| {
+    area.create_config();
+    area.mkdir("docs");
+    area.write_file(
+        Path::new("docs").join("README.md"),
+        indoc! {"
+
+        [Road to nowhere](/nope)
+    "}
+        .as_bytes(),
+    );
+
+    let result = area.cmd(&["build"]);
+    assert_failed(&result);
+
+    let stderr = std::str::from_utf8(&result.stderr).unwrap();
+
+    println!("{}", stderr);
+
+    assert!(stderr.contains("Detected broken internal links"));
+    assert!(stderr.contains("/nope"));
+    assert!(stderr.contains("Road to nowhere"));
 });


### PR DESCRIPTION
Closes #13

This feature adds broken links checking into the `serve` and `build` processes. It actually already uncovered a couple broken links we had in our own docs!

If there are broken internal links, the `build` process will return an error. Users can opt out of these errors by using the `--allow-failed-checks` flag. This keeps the option open to adding futher checks in the future if we want.

This change also includes a decent refactoring of how Doctave actually generates sites. Now each command interacts with a `Site` struct that is generic over a backend implementation (disk or in-memory). The `Site` is responsible of loading docs from disk, and then passing them to the backend once the HTML has been generated.