### PR TITLE
Upgrade arg parsing to clap v3 with derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,15 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "ascii"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,17 +185,41 @@ checksum = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "47582c09be7c8b32c0ab3a6181825ababb713fde6fff20fc573a3870dd45c6a0"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -295,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "doctave"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "alphanumeric-sort",
  "ascii",
@@ -368,7 +383,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf85aeacc72b7b5d9e78b39399562a2846566936e41a6f59f9d96b3fa7c4f96"
 dependencies = [
- "strsim 0.10.0",
+ "strsim",
 ]
 
 [[package]]
@@ -495,6 +510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +523,12 @@ checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -582,6 +609,16 @@ checksum = "5e074c19deab2501407c91ba1860fa3d6820bfde307db6d8cb851b55a10be89b"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -750,9 +787,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -881,6 +918,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "parking_lot"
@@ -1027,10 +1070,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.20"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -1054,9 +1121,9 @@ checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1311,12 +1378,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -1333,7 +1394,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
- "heck",
+ "heck 0.3.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -1341,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.40"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1363,21 +1424,18 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thread_local"
@@ -1483,12 +1541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,12 +1580,6 @@ name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Niklas Begley <nik@doctave.com>"]
 edition = "2018"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "3.1", features = ["derive"] }
 walkdir = "2.3.1"
 doctave-markdown = { git = "https://github.com/Doctave/doctave-markdown", tag = "0.9.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,75 +1,69 @@
+use std::path::PathBuf;
+
 use bunt::termcolor::{ColorChoice, StandardStream};
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{Parser, Subcommand};
+
+/// An opinionated static site generator
+/// designed specifically for technical documentation
+#[derive(Parser)]
+#[clap(name = "Doctave", version)]
+struct Cli {
+    /// Disable terminal color output
+    #[clap(long, global = true)]
+    no_color: bool,
+
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Initialize a new project (start here!)
+    Init {
+        /// An optional custom root directory for your documentation (defaults to docs/)
+        #[clap(long)]
+        docs_dir: Option<PathBuf>,
+    },
+
+    /// Build your site from the project's Markdown files
+    Build {
+        /// Build the site in release mode
+        #[clap(long)]
+        release: bool,
+
+        /// Don't return an error if there are failed checks
+        #[clap(long)]
+        allow_failed_checks: bool,
+    },
+
+    /// Start a live reloading development server
+    /// to serve your documentation site
+    Serve {
+        /// Port used to serve the documentation site.
+        /// Must be a positive integer.
+        #[clap(short, long)]
+        port: Option<u32>,
+    },
+}
 
 fn main() {
-    let matches = App::new("Doctave")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about(
-            "An opinionated static site generator designed specifically \
-               for technical documentation.",
-        )
-        .arg(
-            Arg::with_name("no-color")
-                .long("no-color")
-                .help("Disable terminal color output")
-                .global(true),
-        )
-        .subcommand(
-            SubCommand::with_name("init")
-                .about("Initialize a new project (start here!)")
-                .arg(Arg::with_name("docs-dir").long("docs-dir").help(
-                    "An optional custom root directory for your documentation. (Defaults to docs/)",
-                ).takes_value(true)),
-        )
-        .subcommand(
-            SubCommand::with_name("build")
-                .about("Builds your site from the project's Markdown files")
-                .arg(
-                    Arg::with_name("release")
-                        .long("release")
-                        .help("Build the site in release mode"),
-                )
-                .arg(
-                    Arg::with_name("allow-failed-checks")
-                        .long("allow-failed-checks")
-                        .help("Don't return an error if there are failed checks"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("serve")
-                .about(
-                    "Starts a live reloading development server to serve your documentation site",
-                )
-                .arg(
-                    Arg::with_name("port")
-                        .long("port")
-                        .short("p")
-                        .takes_value(true)
-                        .value_name("PORT")
-                        .help(
-                            "Port used to serve the documentation site. \
-                             Must be a positive integer.",
-                        )
-                        .validator(|p| match p.parse::<u32>() {
-                            Ok(_) => Ok(()),
-                            Err(e) => Err(e.to_string()),
-                        }),
-                ),
-        )
-        .get_matches();
-
-    let result = match matches.subcommand() {
-        ("init", Some(cmd)) => init(cmd),
-        ("build", Some(cmd)) => build(cmd),
-        ("serve", Some(cmd)) => serve(cmd),
-        _ => Ok(()),
+    let cli = Cli::parse();
+    let no_color = cli.no_color;
+    let result = match cli.command {
+        Command::Init { docs_dir } => init(no_color, docs_dir),
+        Command::Build {
+            release,
+            allow_failed_checks,
+        } => build(no_color, release, allow_failed_checks),
+        Command::Serve { port } => serve(no_color, port),
     };
 
-    let mut out = if matches.value_of("no-color").is_some() {
-        StandardStream::stdout(ColorChoice::Never)
+    let color_choice = if no_color {
+        ColorChoice::Never
     } else {
-        StandardStream::stdout(ColorChoice::Auto)
+        ColorChoice::Auto
     };
+    let mut out = StandardStream::stdout(color_choice);
 
     if let Err(e) = result {
         bunt::writeln!(out, "{$red}ERROR:{/$} {}", e).unwrap();
@@ -77,48 +71,43 @@ fn main() {
     }
 }
 
-fn init(cmd: &ArgMatches) -> doctave::Result<()> {
+fn init(no_color: bool, docs_dir: Option<PathBuf>) -> doctave::Result<()> {
     let root_dir = std::env::current_dir().expect("Unable to determine current directory");
-    let doc_root = cmd.value_of("docs-dir").map(|str| str.to_string());
-    doctave::InitCommand::run(root_dir, !cmd.is_present("no-color"), doc_root)
+    doctave::InitCommand::run(root_dir, !no_color, docs_dir)
 }
 
-fn build(cmd: &ArgMatches) -> doctave::Result<()> {
+fn build(no_color: bool, release: bool, allow_failed_checks: bool) -> doctave::Result<()> {
     let project_dir = doctave::config::project_root().unwrap_or_else(|| {
         println!("Could not find a doctave project in this directory, or its parents.");
         std::process::exit(1);
     });
 
     let mut config = doctave::Config::load(&project_dir)?;
-    if cmd.is_present("release") {
+    if release {
         config.set_build_mode(doctave::BuildMode::Release);
     }
 
-    if cmd.is_present("no-color") {
+    if no_color {
         config.disable_colors();
     }
 
-    if cmd.is_present("allow-failed-checks") {
+    if allow_failed_checks {
         config.set_allow_failed_checks();
     }
 
     doctave::BuildCommand::run(config)
 }
 
-fn serve(cmd: &ArgMatches) -> doctave::Result<()> {
+fn serve(no_color: bool, port: Option<u32>) -> doctave::Result<()> {
     let project_dir = doctave::config::project_root().unwrap_or_else(|| {
         println!("Could not find a doctave project in this directory, or its parents.");
         std::process::exit(1);
     });
 
-    let mut options = doctave::ServeOptions::default();
+    let options = doctave::ServeOptions { port };
     let mut config = doctave::Config::load(&project_dir)?;
 
-    if let Some(p) = cmd.value_of("port") {
-        options.port = Some(p.parse::<u32>().unwrap());
-    }
-
-    if cmd.is_present("no-color") {
+    if no_color {
         config.disable_colors();
     }
 


### PR DESCRIPTION
Changes the arg parsing to use clap 3.0 with its newly added `derive` feature, that largely simplifies command line definition and automates away some boilerplate type parsing (notably the `port` flag).

Note: by default clap now outputs colorful help prompts, let me know if it should be disabled.