### PR TITLE
Add BASE_PATH to Prism autoloader languages_path

### DIFF
--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -177,7 +177,7 @@ for (let element of mathElements) {
 }
 
 // Setup Prism
-Prism.plugins.autoloader.languages_path = '/assets/prism-grammars/';
+Prism.plugins.autoloader.languages_path = BASE_PATH + 'assets/prism-grammars/';
 
 
 // Load search index


### PR DESCRIPTION
This change prefixes the Prism grammar folder (`assets/prism-grammars/`) with the base path, used when autoloading grammers.