### PR TITLE
feat: initial add of flake for builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /_test_area
 /site
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,126 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1649096192,
+        "narHash": "sha256-7O8e+eZEYeU+ET98u/zW5epuoN/xYx9G+CIh4DjZVzY=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "d626f73332a8f587b613b0afe7293dd0777be07d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1649266099,
+        "narHash": "sha256-dp10Qrhco2CP/MGxX5Kf0uegpv5YsWL97SWG3+ocp3c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "590eddce3a65724987dd2010b0c61c29a68a3508",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1637453606,
+        "narHash": "sha256-Gy6cwUswft9xqsjWxFYEnx/63/qzaFUwatcbV5GF/GQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8afc4e543663ca0a6a4f496262cd05233737e732",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay",
+        "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1649212438,
+        "narHash": "sha256-inr/6z2/3aekw3HP51dSSjbY6oPaaOmd1yHqRbnPHr0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "69e0fdf70582e1b1e3b4d84e5201ca72b58b5b9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "an opinionated documentation site generator";
+
+  # inputs needed for rust along with some nice tooling for development environment
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    naersk.url = "github:nix-community/naersk";
+  };
+
+  outputs = { self, nixpkgs, utils, rust-overlay, naersk, ... }:
+    let
+      name = "doctave";
+    in
+    utils.lib.eachDefaultSystem (system:
+      let
+        # nix packages with rust overlay defaulats instead
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            rust-overlay.overlay
+            (self: super: {
+              rustc = self.rust-bin.stable.latest.default;
+              cargo = self.rust-bin.stable.latest.default;
+            })
+          ];
+        };
+
+        # override version cargo and rustc version of naersk with overlay
+        naersk-lib = naersk.lib.${system}.override {
+          cargo = pkgs.cargo;
+          rustc = pkgs.rustc;
+        };
+
+      in
+      rec {
+        # main package to base all builds from
+        packages.${name} = naersk-lib.buildPackage {
+          pname = name;
+          # root of rust source holding cargo.lock
+          root = ./.;
+        };
+        defaultPackage = packages.${name};
+        # build out a container image if want to run as a container
+        packages.container = pkgs.dockerTools.buildImage {
+          inherit name;
+          tag = packages.${name}.version;
+          created = "now";
+          contents = packages.${name};
+          config.Cmd = [ "${packages.${name}}/bin/doctave" ];
+        };
+        # useful default app to run from nix directly
+        apps.${name} = utils.lib.mkApp {
+          inherit name;
+          drv = packages.${name};
+        };
+        defaultApp = apps.${name};
+
+        # dev shell default
+        devShell = pkgs.mkShell {
+          shellHook = ''
+            export RUST_SRC_PATH=${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}
+          '';
+
+          nativeBuildInputs = [ pkgs.cargo ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Hi, 

Started playing with using doctave. Been looking at stuff that I would like contribute to the project. But before then, created a quick [nix flake][1] file to make it seamlessly simple to get started on the repository without worrying about package needs or build process as time moves forward and the project grows. Nothing too fancy here, but enough to be able to set up a development environment, package for releases, docker image package generation, and a source reference to use with the larger nix ecosystem. 

The following patch introduces nix flakes. Allowing the set up of
using nix flakes for buildng packages in reference
to the repository, idempotent reproducible development environment
for ease in contributing, and the ability to create packages for
multiple different targets including docker container images.

[1]: https://nixos.wiki/wiki/Flakes